### PR TITLE
[feat] 카카오 맵 초기 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,12 @@ android {
     }
 
     defaultConfig {
+
+        configurations.all {
+            resolutionStrategy { force 'androidx.core:core-ktx:1.6.0' }
+        }
+
+
         applicationId "com.example.foodvillage"
         minSdkVersion 23
         targetSdkVersion 30
@@ -34,6 +40,14 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'x86_64', 'armeabi-v7a', 'armeabi'
+            universalApk false
+        }
+    }
 }
 
 apply plugin: 'com.android.application'
@@ -54,4 +68,10 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation files('libs/libDaumMapAndroid.jar')
+    implementation 'com.google.android.gms:play-services-maps:17.0.0'
+    implementation 'com.google.android.gms:play-services-location:18.0.0'
+    implementation 'gun0912.ted:tedpermission:2.2.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.foodvillage">
 
-    <uses-permission android:name="android.permission.INTERNET " />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -10,16 +12,24 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.FoodVillage">
+        android:theme="@style/Theme.FoodVillage"
+        android:usesCleartextTraffic="true">
+        <activity android:name=".MarketMapActivity"></activity>
+        <activity android:name=".MyMapActivity" />
         <activity android:name=".LoginActivity">
+        </activity>
+        <activity android:name=".MainActivity" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".MainActivity">
-        </activity>
+
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="fa4beeecb60297b77f7dd90a3b2d4c64" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/foodvillage/LoginActivity.kt
+++ b/app/src/main/java/com/example/foodvillage/LoginActivity.kt
@@ -1,8 +1,13 @@
 package com.example.foodvillage
 
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.Signature
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Base64
+import android.util.Log
 import android.widget.Toast
 import com.example.foodvillage.databinding.ActivityLoginBinding
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -13,6 +18,8 @@ import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
 
 class LoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLoginBinding
@@ -25,6 +32,9 @@ class LoginActivity : AppCompatActivity() {
         binding = ActivityLoginBinding.inflate(layoutInflater)
         val view = binding.root
         setContentView(view)
+        
+        // 맵 사용 등록을 위한 해시 키 생성 함수
+//        getHashKey()
 
         auth = FirebaseAuth.getInstance()
 
@@ -43,6 +53,27 @@ class LoginActivity : AppCompatActivity() {
 
         googleSignInClient = GoogleSignIn.getClient(this, gso)
     }
+
+    fun getHashKey(){
+        var packageInfo : PackageInfo = PackageInfo()
+        try {
+            packageInfo = packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+        } catch (e: PackageManager.NameNotFoundException){
+            e.printStackTrace()
+        }
+
+        for (signature: Signature in packageInfo.signatures){
+            try{
+                var md: MessageDigest = MessageDigest.getInstance("SHA")
+                md.update(signature.toByteArray())
+                Log.e("KEY_HASH", Base64.encodeToString(md.digest(), Base64.DEFAULT))
+            } catch(e: NoSuchAlgorithmException){
+                Log.e("KEY_HASH", "Unable to get MessageDigest. signature = " + signature, e)
+            }
+        }
+    }
+
+
 
     // 로그인 한 적이 있는지 확인
     public override fun onStart() {

--- a/app/src/main/java/com/example/foodvillage/MainActivity.kt
+++ b/app/src/main/java/com/example/foodvillage/MainActivity.kt
@@ -1,11 +1,30 @@
 package com.example.foodvillage
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.example.foodvillage.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private var mBinding: ActivityMainBinding? = null
+    private val binding get() = mBinding!!
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // 바인딩
+        mBinding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.btnMainactivityTomymap.setOnClickListener{
+            val intent= Intent(this@MainActivity, MyMapActivity::class.java)
+            startActivity(intent)
+        }
+        binding.btnMainactivityTomarketmap.setOnClickListener{
+            val intent= Intent(this@MainActivity, MarketMapActivity::class.java)
+            startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/example/foodvillage/MarketMapActivity.kt
+++ b/app/src/main/java/com/example/foodvillage/MarketMapActivity.kt
@@ -1,0 +1,331 @@
+package com.example.foodvillage
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.location.Location
+import android.os.Build
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.core.app.ActivityCompat
+import com.example.foodvillage.databinding.ActivityMarketMapBinding
+import com.google.android.gms.location.*
+import net.daum.mf.map.api.*
+import java.lang.Math.*
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.math.pow
+
+class MarketMapActivity : AppCompatActivity(), MapView.CurrentLocationEventListener{
+    // 뷰 바인딩
+    private var mBinding: ActivityMarketMapBinding? = null
+    private val binding get() = mBinding!!
+
+    private var mapView: MapView?=null
+
+    private val eventListener = MarkerEventListener(this)   // 마커 클릭 이벤트 리스너
+
+    // 위치 추적을 위한 변수들
+    val TAG: String = "로그"
+    private var mFusedLocationProviderClient: FusedLocationProviderClient? = null // 현재 위치를 가져오기 위한 변수
+    lateinit var mLastLocation: Location // 위치 값을 가지고 있는 객체
+    internal lateinit var mLocationRequest: LocationRequest // 위치 정보 요청의 매개변수를 저장하는
+    private val REQUEST_PERMISSION_LOCATION = 10
+
+    val curr_lat=37.5406564
+    val curr_lon=126.8809048
+
+    val market_lat1=37.544
+    val market_lon1=126.884
+
+    val market_lat2=37.539
+    val market_lon2=126.882
+
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_market_map)
+// 바인딩
+        mBinding = ActivityMarketMapBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // 맵
+        // 임포트 잘 해줘야함... mf들어간걸로!
+        mapView = MapView(this)
+        binding.clKakaoMapView2.addView(mapView)
+        mapView!!.setCurrentLocationEventListener(this)
+        mapView!!.setPOIItemEventListener(eventListener)
+
+
+        // 현재 위치
+        // LocationRequest() deprecated 되서 아래 방식으로 LocationRequest 객체 생성
+        // mLocationRequest = LocationRequest() is deprecated
+        mLocationRequest =  LocationRequest.create().apply {
+            interval = 1000 // 업데이트 간격 단위(밀리초)
+            //fastestInterval = 1000 // 가장 빠른 업데이트 간격 단위(밀리초)
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY // 정확성
+            //maxWaitTime= 2000 // 위치 갱신 요청 최대 대기 시간 (밀리초)
+        }
+
+        // 위치 추척 시작
+        if (checkPermissionForLocation(this)) {
+            startLocationUpdates()
+
+            // 현위치 트래킹 - 이건 주소 설정할 때 해서 최초로 받는거
+            mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOnWithMarkerHeadingWithoutMapMoving);
+
+        }
+
+
+    }
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOff)
+        mapView!!.setShowCurrentLocationMarker(false)
+    }
+
+    protected fun startLocationUpdates() {
+        Log.d(TAG, "startLocationUpdates()")
+
+        //FusedLocationProviderClient의 인스턴스를 생성.
+        mFusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+            && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "startLocationUpdates() 두 위치 권한중 하나라도 없는 경우 ")
+            return
+        }
+        Log.d(TAG, "startLocationUpdates() 위치 권한이 하나라도 존재하는 경우")
+        // 기기의 위치에 관한 정기 업데이트를 요청하는 메서드 실행
+        // 지정한 루퍼 스레드(Looper.myLooper())에서 콜백(mLocationCallback)으로 위치 업데이트를 요청합니다.
+        mFusedLocationProviderClient!!.requestLocationUpdates(
+            mLocationRequest,
+            mLocationCallback,
+            Looper.myLooper()
+        )
+
+        // 내 위치로 중심 이동
+        val mapPoint = MapPoint.mapPointWithGeoCoord(curr_lat, curr_lon)
+        mapView?.setMapCenterPoint(mapPoint, true)
+        mapView?.setZoomLevel(1, true)
+
+        //마커 생성1
+        val marker = MapPOIItem()
+        val mapPoint_market1 = MapPoint.mapPointWithGeoCoord(market_lat1, market_lon1)
+        marker.itemName = "나연마트1"
+        marker.mapPoint = mapPoint_market1
+        marker.markerType = MapPOIItem.MarkerType.BluePin
+        marker.selectedMarkerType = MapPOIItem.MarkerType.RedPin
+
+        // markers 가능
+        mapView?.addPOIItem(marker)
+
+        //마커 생성2
+        val marker2=MapPOIItem()
+        val mapPoint_market2 = MapPoint.mapPointWithGeoCoord(market_lat2, market_lon2)
+        marker2.itemName = "나연마트2"
+        marker2.mapPoint = mapPoint_market2
+        marker2.markerType = MapPOIItem.MarkerType.BluePin
+        marker2.selectedMarkerType = MapPOIItem.MarkerType.RedPin
+
+        mapView?.addPOIItem(marker2)
+
+        // 다 보이게 레벨 조정
+        mapView!!.fitMapViewAreaToShowAllPOIItems()
+
+
+    }
+
+    // 시스템으로 부터 위치 정보를 콜백으로 받음
+    private val mLocationCallback = object : LocationCallback() {
+        override fun onLocationResult(locationResult: LocationResult) {
+            Log.d(TAG, "onLocationResult()")
+            // 시스템에서 받은 location 정보를 onLocationChanged()에 전달
+            locationResult.lastLocation
+            onLocationChanged(locationResult.lastLocation)
+        }
+    }
+
+    // 시스템으로 부터 받은 위치정보를 화면에 갱신해주는 메소드
+    fun onLocationChanged(location: Location) {
+        Log.d(TAG, "onLocationChanged()")
+        mLastLocation = location
+        val date: Date = Calendar.getInstance().time
+        val simpleDateFormat = SimpleDateFormat("hh:mm:ss a")
+//        txtTime.text = "Updated at : " + simpleDateFormat.format(date) // 갱신된 날짜
+        //수원 화성의 위도, 경도
+        val mapPoint = MapPoint.mapPointWithGeoCoord(
+            mLastLocation.latitude,
+            mLastLocation.longitude
+        )
+        Log.d(TAG, "위도: " + mLastLocation.latitude + ", 경도: " + mLastLocation.longitude)
+        /*
+            여기서 현 위치 로그가 나오는데, 지도찾기할 때 이거 사용하고
+            버튼 클릭 - 현 위치로 설정? -> 예 선택 시 저장
+            -> 아니오시 계속 트래킹!
+         */
+
+    }
+
+    // 위치 권한이 있는지 확인하는 메서드
+    fun checkPermissionForLocation(context: Context): Boolean {
+        Log.d(TAG, "checkPermissionForLocation()")
+        // Android 6.0 Marshmallow 이상에서는 지리 확보(위치) 권한에 추가 런타임 권한이 필요합니다.
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "checkPermissionForLocation() 권한 상태 : O")
+                true
+            } else {
+                // 권한이 없으므로 권한 요청 알림 보내기
+                Log.d(TAG, "checkPermissionForLocation() 권한 상태 : X")
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION),
+                    REQUEST_PERMISSION_LOCATION
+                )
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    // 사용자에게 권한 요청 후 결과에 대한 처리 로직
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        Log.d(TAG, "onRequestPermissionsResult()")
+        if (requestCode == REQUEST_PERMISSION_LOCATION) {
+            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "onRequestPermissionsResult() _ 권한 허용 클릭")
+                startLocationUpdates()
+
+                // 현위치 트래킹
+                mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOnWithMarkerHeadingWithoutMapMoving);
+
+
+//                // View Button 활성화 상태 변경
+//                btnStartupdate.isEnabled = false
+//                btnStopUpdates.isEnabled = true
+
+            } else {
+                Log.d(TAG, "onRequestPermissionsResult() _ 권한 허용 거부")
+                Toast.makeText(this@MarketMapActivity, "권한이 없어 해당 기능을 실행할 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onCurrentLocationUpdate(p0: MapView, p1: MapPoint, p2: Float) {
+        val mapPointGeo: MapPoint.GeoCoordinate = p1.getMapPointGeoCoord()
+        Log.i(
+            "로그",
+            java.lang.String.format(
+                "MapView onCurrentLocationUpdate (%f,%f) accuracy (%f)",
+                mapPointGeo.latitude,
+                mapPointGeo.longitude,
+                p2
+            )
+        )
+    }
+
+    override fun onCurrentLocationDeviceHeadingUpdate(p0: MapView?, p1: Float) {
+
+    }
+
+    override fun onCurrentLocationUpdateFailed(p0: MapView?) {
+
+    }
+
+    override fun onCurrentLocationUpdateCancelled(p0: MapView?) {
+
+    }
+
+    class MarkerEventListener(val context: Context): MapView.POIItemEventListener {
+        var marker_distance:Int = 0
+
+        override fun onPOIItemSelected(mapView: MapView?, marker: MapPOIItem?) {
+            Log.d("마커","onPOIItemSelected()")
+            mapView!!.removeAllPolylines()
+
+            val curr_lat=37.5406564
+            val curr_lon=126.8809048
+
+            // 라인 생성
+            // 폴리 라인
+            val polyline = MapPolyline()
+            polyline.tag = 1000
+            polyline.lineColor = Color.argb(128, 0, 0, 0) // Polyline 컬러 지정.
+
+            if (marker != null) {
+                // Polyline 좌표 지정
+
+                val market_lat=marker.mapPoint.mapPointGeoCoord.latitude
+                val market_lon=marker.mapPoint.mapPointGeoCoord.longitude
+                polyline.addPoint(MapPoint.mapPointWithGeoCoord(curr_lat, curr_lon))
+                polyline.addPoint(MapPoint.mapPointWithGeoCoord(market_lat, market_lon))
+
+                // Polyline 지도에 올리기.
+                mapView!!.addPolyline(polyline)
+
+                val mapPointBounds = MapPointBounds(polyline.mapPoints)
+                val padding = 100 // px
+
+                mapView!!.moveCamera(CameraUpdateFactory.newMapPointBounds(mapPointBounds, padding))
+
+                marker_distance=getDistance(curr_lat, curr_lon, market_lat, market_lon)
+            }
+        }
+
+        override fun onCalloutBalloonOfPOIItemTouched(mapView: MapView?, poiItem: MapPOIItem?) {
+            // 말풍선 클릭 시 (Deprecated)
+            // 이 함수도 작동하지만 그냥 아래 있는 함수에 작성하자
+        }
+
+        override fun onCalloutBalloonOfPOIItemTouched(mapView: MapView?, poiItem: MapPOIItem?, buttonType: MapPOIItem.CalloutBalloonButtonType?) {
+            // 말풍선 클릭 시
+            val builder = AlertDialog.Builder(context)
+            val itemList = arrayOf("토스트", "거리", (marker_distance.toDouble()/1000).toString()+"km")
+            builder.setTitle("${poiItem?.itemName}")
+            builder.setItems(itemList) { dialog, which ->
+                when(which) {
+                    0 -> Toast.makeText(context, "토스트", Toast.LENGTH_SHORT).show()  // 토스트
+                    1 -> mapView?.removePOIItem(poiItem)    // 마커 삭제
+                    2 -> dialog.dismiss()   // 대화상자 닫기
+                }
+            }
+            builder.show()
+        }
+
+        override fun onDraggablePOIItemMoved(mapView: MapView?, poiItem: MapPOIItem?, mapPoint: MapPoint?) {
+            // 마커의 속성 중 isDraggable = true 일 때 마커를 이동시켰을 경우
+        }
+
+        fun getDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Int {
+            val R = 6372.8 * 1000
+
+            val dLat = Math.toRadians(lat2 - lat1)
+            val dLon = Math.toRadians(lon2 - lon1)
+            val a = sin(dLat / 2).pow(2.0) + sin(dLon / 2).pow(2.0) * cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2))
+            val c = 2 * asin(sqrt(a))
+            return (R * c).toInt()
+        }
+
+
+    }
+
+
+
+
+
+
+
+}
+

--- a/app/src/main/java/com/example/foodvillage/MyMapActivity.kt
+++ b/app/src/main/java/com/example/foodvillage/MyMapActivity.kt
@@ -1,0 +1,259 @@
+package com.example.foodvillage
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.*
+import android.os.Build
+import android.os.Bundle
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import com.example.foodvillage.databinding.ActivityMyMapBinding
+import com.google.android.gms.location.*
+import net.daum.mf.map.api.*
+import net.daum.mf.map.api.MapPoint.GeoCoordinate
+import java.text.SimpleDateFormat
+import java.util.*
+
+
+class MyMapActivity : AppCompatActivity(), MapView.CurrentLocationEventListener {
+
+    // 뷰 바인딩
+    private var mBinding: ActivityMyMapBinding? = null
+    private val binding get() = mBinding!!
+
+
+    private var mapView: MapView?=null
+
+
+    // 위치 추적을 위한 변수들
+    val TAG: String = "로그"
+
+    private var mFusedLocationProviderClient: FusedLocationProviderClient? = null // 현재 위치를 가져오기 위한 변수
+    lateinit var mLastLocation: Location // 위치 값을 가지고 있는 객체
+    internal lateinit var mLocationRequest: LocationRequest // 위치 정보 요청의 매개변수를 저장하는
+    private val REQUEST_PERMISSION_LOCATION = 10
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_my_map)
+
+        // 바인딩
+        mBinding = ActivityMyMapBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+
+        // 맵
+        // 임포트 잘 해줘야함... mf들어간걸로!
+        mapView = MapView(this)
+        binding.clKakaoMapView.addView(mapView)
+        mapView!!.setCurrentLocationEventListener(this);
+
+        // 현재 위치
+        // LocationRequest() deprecated 되서 아래 방식으로 LocationRequest 객체 생성
+        // mLocationRequest = LocationRequest() is deprecated
+        mLocationRequest =  LocationRequest.create().apply {
+            interval = 1000 // 업데이트 간격 단위(밀리초)
+            //fastestInterval = 1000 // 가장 빠른 업데이트 간격 단위(밀리초)
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY // 정확성
+            //maxWaitTime= 2000 // 위치 갱신 요청 최대 대기 시간 (밀리초)
+        }
+
+        // 위치 추척 시작
+        if (checkPermissionForLocation(this)) {
+            startLocationUpdates()
+
+            // 현위치 트래킹 - 이건 주소 설정할 때 해서 최초로 받는거
+            mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOnWithHeading);
+            //TrackingModeOnWithMarkerHeadingWithoutMapMoving);
+
+//                // View Button 활성화 상태 변경
+//                btnStartupdate.isEnabled = false
+//                btnStopUpdates.isEnabled = true
+
+
+        }
+
+
+// 키 해시 얻기
+//        fun getAppKeyHash() {
+//            try {
+//                val info =
+//                        packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+//                for (signature in info.signatures) {
+//                    var md: MessageDigest
+//                    md = MessageDigest.getInstance("SHA")
+//                    md.update(signature.toByteArray())
+//                    val something = String(Base64.encode(md.digest(), 0))
+//                    Log.e("Hash key", something)
+//                }
+//            } catch (e: Exception) {
+//
+//                Log.e("name not found", e.toString())
+//            }
+//        }
+//        getAppKeyHash()
+
+
+    }
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOff)
+        mapView!!.setShowCurrentLocationMarker(false)
+    }
+
+    protected fun startLocationUpdates() {
+        Log.d(TAG, "startLocationUpdates()")
+
+        //FusedLocationProviderClient의 인스턴스를 생성.
+        mFusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+            && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            Log.d(TAG, "startLocationUpdates() 두 위치 권한중 하나라도 없는 경우 ")
+            return
+        }
+        Log.d(TAG, "startLocationUpdates() 위치 권한이 하나라도 존재하는 경우")
+        // 기기의 위치에 관한 정기 업데이트를 요청하는 메서드 실행
+        // 지정한 루퍼 스레드(Looper.myLooper())에서 콜백(mLocationCallback)으로 위치 업데이트를 요청합니다.
+        mFusedLocationProviderClient!!.requestLocationUpdates(
+            mLocationRequest,
+            mLocationCallback,
+            Looper.myLooper()
+        )
+    }
+
+    // 시스템으로 부터 위치 정보를 콜백으로 받음
+    private val mLocationCallback = object : LocationCallback() {
+        override fun onLocationResult(locationResult: LocationResult) {
+            Log.d(TAG, "onLocationResult()")
+            // 시스템에서 받은 location 정보를 onLocationChanged()에 전달
+            locationResult.lastLocation
+            onLocationChanged(locationResult.lastLocation)
+        }
+    }
+
+    // 시스템으로 부터 받은 위치정보를 화면에 갱신해주는 메소드
+    fun onLocationChanged(location: Location) {
+        Log.d(TAG, "onLocationChanged()")
+        mLastLocation = location
+        val date: Date = Calendar.getInstance().time
+        val simpleDateFormat = SimpleDateFormat("hh:mm:ss a")
+//        txtTime.text = "Updated at : " + simpleDateFormat.format(date) // 갱신된 날짜
+//        txtLat.text = "LATITUDE : " + mLastLocation.latitude // 갱신 된 위도
+//        txtLong.text = "LONGITUDE : " + mLastLocation.longitude // 갱신 된 경도
+        //수원 화성의 위도, 경도
+        val mapPoint = MapPoint.mapPointWithGeoCoord(
+            mLastLocation.latitude,
+            mLastLocation.longitude
+        )
+        Log.d(TAG, "위도: " + mLastLocation.latitude + ", 경도: " + mLastLocation.longitude)
+        /*
+            여기서 현 위치 로그가 나오는데, 지도찾기할 때 이거 사용하고
+            버튼 클릭 - 현 위치로 설정? -> 예 선택 시 저장
+            -> 아니오시 계속 트래킹!
+
+         */
+//        // 내 마커 찍는데 안 없어져서 트래킹 모드로 바꾸려고!
+//        //지도의 중심점을 수원 화성으로 설정, 확대 레벨 설정 (값이 작을수록 더 확대됨)
+//        mapView?.setMapCenterPoint(mapPoint, true)
+//        mapView?.setZoomLevel(1, true)
+//
+//        //마커 생성
+//        val marker = MapPOIItem()
+//        marker.itemName = "현재 위치"
+//        marker.mapPoint = mapPoint
+////        marker.markerType = MapPOIItem.MarkerType.BluePin
+////        marker.selectedMarkerType = MapPOIItem.MarkerType.RedPin
+//
+//        marker.setMarkerType(MapPOIItem.MarkerType.CustomImage)
+//        marker.customImageResourceId = R.drawable.custom_marker
+//
+//        marker.setCustomImageAnchor(0.5f, 1.0f)
+//        mapView?.addPOIItem(marker)
+
+    }
+
+    // 위치 권한이 있는지 확인하는 메서드
+    fun checkPermissionForLocation(context: Context): Boolean {
+        Log.d(TAG, "checkPermissionForLocation()")
+        // Android 6.0 Marshmallow 이상에서는 지리 확보(위치) 권한에 추가 런타임 권한이 필요합니다.
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "checkPermissionForLocation() 권한 상태 : O")
+                true
+            } else {
+                // 권한이 없으므로 권한 요청 알림 보내기
+                Log.d(TAG, "checkPermissionForLocation() 권한 상태 : X")
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION),
+                    REQUEST_PERMISSION_LOCATION
+                )
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    // 사용자에게 권한 요청 후 결과에 대한 처리 로직
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        Log.d(TAG, "onRequestPermissionsResult()")
+        if (requestCode == REQUEST_PERMISSION_LOCATION) {
+            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Log.d(TAG, "onRequestPermissionsResult() _ 권한 허용 클릭")
+                startLocationUpdates()
+
+                // 현위치 트래킹
+                mapView!!.setCurrentLocationTrackingMode(MapView.CurrentLocationTrackingMode.TrackingModeOnWithMarkerHeadingWithoutMapMoving);
+
+
+//                // View Button 활성화 상태 변경
+//                btnStartupdate.isEnabled = false
+//                btnStopUpdates.isEnabled = true
+
+
+            } else {
+                Log.d(TAG, "onRequestPermissionsResult() _ 권한 허용 거부")
+                Toast.makeText(this@MyMapActivity, "권한이 없어 해당 기능을 실행할 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onCurrentLocationUpdate(p0: MapView, p1: MapPoint, p2: Float) {
+        val mapPointGeo: GeoCoordinate = p1.getMapPointGeoCoord()
+        Log.i(
+            "로그",
+            java.lang.String.format(
+                "MapView onCurrentLocationUpdate (%f,%f) accuracy (%f)",
+                mapPointGeo.latitude,
+                mapPointGeo.longitude,
+                p2
+            )
+        )
+    }
+
+    override fun onCurrentLocationDeviceHeadingUpdate(p0: MapView?, p1: Float) {
+
+    }
+
+    override fun onCurrentLocationUpdateFailed(p0: MapView?) {
+
+    }
+
+    override fun onCurrentLocationUpdateCancelled(p0: MapView?) {
+
+    }
+
+
+}

--- a/app/src/main/res/layout/activity_market_map.xml
+++ b/app/src/main/res/layout/activity_market_map.xml
@@ -4,36 +4,36 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MarketMapActivity">
 
     <TextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        android:layout_margin="20dp"
+        android:text="안드로이드 카카오맵 API 활용 : \nMapView 띄우기"
+        android:textColor="#822FD5"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/btn_mainactivity_tomymap"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="tomymap"
-        app:layout_constraintBottom_toTopOf="@+id/btn_mainactivity_tomarketmap"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clKakaoMapView2"
+        android:layout_width="match_parent"
+        android:layout_height="500dp"
+        android:layout_marginTop="20dp"
         app:layout_constraintTop_toBottomOf="@+id/textView" />
 
     <Button
-        android:id="@+id/btn_mainactivity_tomarketmap"
+        android:id="@+id/btn_MainActivity_toLatLng"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="tomarketmap"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btn_mainactivity_tomymap" />
+        app:layout_constraintTop_toBottomOf="@+id/clKakaoMapView2" />
+
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_my_map.xml
+++ b/app/src/main/res/layout/activity_my_map.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MyMapActivity">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text="안드로이드 카카오맵 API 활용 : \nMapView 띄우기"
+        android:textColor="#822FD5"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clKakaoMapView"
+        android:layout_width="match_parent"
+        android:layout_height="500dp"
+        android:layout_marginTop="20dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# file
- Manifest, gradle 수정 및 추가
  + manifest에서 시작 액티비티 MainActivity.kt로 지정함
  + 그 외 각종 dependencies, implements 등등 추가함
- app/libs/\*, app/src/main/jniLibs/\* 생성

# function
- LoginActivity.kt
  + 카카오맵 사용을 위한 hash key 얻는 코드 추가
- MainActivity.kt
  + 각 액티비티로 가는 버튼 추가
- MyMapActivity.kt
  + 나의 위치를 맵에 나타냄
- MarketMapActivity.kt
  + 나와 마켓(marker)의 위치를 나타냄
  + marker를 클릭하면 마커 정보와 marker까지의 거리, 나의 위치와 marker를 잇는 polyline 생성 + 줌 인

# toDo
- 위경도 <-> 주소 변동 해보기
- Balloon에다가 사람 모양이랑 시간? 띄우기
  + 클릭시 다이얼로그 말고 하단에 가게 관련 뷰 뜨게 하기
- CustomMarker 만들어놓기(drawable 크기 수정해보기)
- 길찾기/검색 url 가능한지 해보기